### PR TITLE
Follow-ups: cache-timestamp persistence, formatter dedup, config template, tests/CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,23 @@ jobs:
           python -m compileall -q
           plexbot.py media_cache.py tautulli_wrapper.py utilities.py migration.py
           config errors cogs
+
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        # Installing the pinned requirements also verifies they resolve together
+        # on the supported Python version.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Run tests
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -129,8 +129,10 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# JSON files
+# JSON files (config.json, map.json, the media cache, etc. — may hold secrets)
 *.json
+# ...but ship the committed config template
+!config.example.json
 
 #PyCharm / VSCode files
 .idea/

--- a/README.md
+++ b/README.md
@@ -48,8 +48,14 @@ A Discord bot that interfaces with your Plex server through Tautulli's API, offe
    ```
    
    **Option 2: Create a new configuration**
-   
-   Create a `config.json` file in the root directory based on this structure:
+
+   Copy the bundled template and fill in your values:
+
+   ```bash
+   cp config.example.json config.json
+   ```
+
+   The template mirrors this structure (everything not listed falls back to sensible defaults):
 
    ```json
    {

--- a/cogs/media_commands.py
+++ b/cogs/media_commands.py
@@ -14,6 +14,7 @@ from utilities import (
     UserMappings,
     NoStopButtonMenuPages,
     prepare_thumbnail_for_embed,
+    format_duration,
 )
 from tautulli_wrapper import Tautulli, TMDB
 from media_cache import MediaCache
@@ -34,15 +35,6 @@ def _format_ms(ms: int) -> str:
     if hours:
         return f"{hours}:{minutes:02d}:{seconds:02d}"
     return f"{minutes}:{seconds:02d}"
-
-
-def _format_seconds(seconds: int) -> str:
-    """Format seconds into a human-readable duration like '2h 15m' or '45m'."""
-    hours, remainder = divmod(int(seconds), 3600)
-    minutes = remainder // 60
-    if hours > 0:
-        return f"{hours}h {minutes}m" if minutes else f"{hours}h"
-    return f"{minutes}m"
 
 
 def _format_bytes_speed(bps: int) -> str:
@@ -783,7 +775,7 @@ class MediaCommands(commands.Cog):
             stats_item = watch_time_stats[0]
             total_time = stats_item.get("total_time", 0)
             if total_time > 0:
-                embed.add_field(name="Total Watch Time", value=_format_seconds(total_time), inline=True)
+                embed.add_field(name="Total Watch Time", value=format_duration(total_time), inline=True)
             last_watch = stats_item.get("last_watch")
             if last_watch:
                 try:

--- a/cogs/plex_stats.py
+++ b/cogs/plex_stats.py
@@ -6,28 +6,13 @@ from datetime import timedelta, datetime
 import nextcord
 from nextcord.ext import commands
 
-from utilities import UserMappings
+from utilities import UserMappings, format_duration
 from config import config
 from tautulli_wrapper import Tautulli
 
 # Configure logging for this module
 logger = logging.getLogger("plexbot.plex_stats")
 logger.setLevel(logging.INFO)
-
-
-def _format_watch_duration(seconds: int) -> str:
-    """Format seconds into a compact duration like '2d 5h 30m' or '5h 12m'."""
-    days, remainder = divmod(int(seconds), 86400)
-    hours, remainder = divmod(remainder, 3600)
-    minutes = remainder // 60
-    parts = []
-    if days:
-        parts.append(f"{days}d")
-    if hours:
-        parts.append(f"{hours}h")
-    if minutes or not parts:
-        parts.append(f"{minutes}m")
-    return " ".join(parts)
 
 
 class PlexStats(commands.Cog):
@@ -101,7 +86,7 @@ class PlexStats(commands.Cog):
             username = entry["user"]
             watch_seconds = entry["total_duration"]
             total_watchtime += watch_seconds
-            watch_str = _format_watch_duration(watch_seconds)
+            watch_str = format_duration(watch_seconds)
 
             # What they've been watching
             media_type = entry.get("media_type")
@@ -128,7 +113,7 @@ class PlexStats(commands.Cog):
         embed.description = "\n".join(lines)
 
         # Footer with totals
-        footer_parts = [f"Total: {_format_watch_duration(total_watchtime)}"]
+        footer_parts = [f"Total: {format_duration(total_watchtime)}"]
         history_resp = await self.tautulli.get_history()
         if Tautulli.check_response(history_resp):
             all_time = Tautulli.get_response_data(history_resp, {}).get("total_duration")
@@ -228,7 +213,7 @@ class PlexStats(commands.Cog):
 
             library_line = f"{total_movies} movies  \u2022  {total_shows} shows  \u2022  {total_episodes} episodes"
             if total_duration_seconds:
-                library_line += f"  \u2022  {_format_watch_duration(total_duration_seconds)} watched"
+                library_line += f"  \u2022  {format_duration(total_duration_seconds)} watched"
 
             embed = nextcord.Embed(
                 title=f"Plex Server Stats \u2014 Last {time} Days",
@@ -324,7 +309,7 @@ class PlexStats(commands.Cog):
             lines = []
             for i, (username, data) in enumerate(ranked, 1):
                 prefix = medal.get(i, f"`#{i}`")
-                watch_str = _format_watch_duration(data["time"])
+                watch_str = format_duration(data["time"])
                 libs = ", ".join(data["libraries"])
                 lines.append(f"{prefix}  **{username}** \u2014 {watch_str}\n\u2003\u2003{libs}")
 
@@ -394,7 +379,7 @@ class PlexStats(commands.Cog):
             title = entry.get("full_title", entry.get("title", "Unknown"))
             timestamp = entry.get("date")
             duration_s = entry.get("duration", 0)
-            duration_str = _format_watch_duration(duration_s) if duration_s else ""
+            duration_str = format_duration(duration_s) if duration_s else ""
 
             time_str = f"<t:{timestamp}:R>" if timestamp else ""
             user_suffix = f"  \u2022  {user}" if not plex_username else ""

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,27 @@
+{
+    "core": {
+        "token": "",
+        "prefix": "plex ",
+        "log_level": "INFO"
+    },
+    "tautulli": {
+        "ip": "localhost:8181",
+        "apikey": "",
+        "use_https": false
+    },
+    "discord": {
+        "server_id": "",
+        "top_role_id": 0,
+        "second_role_id": 0,
+        "third_role_id": 0
+    },
+    "qbittorrent": {
+        "ip": "localhost",
+        "port": "8080",
+        "username": "",
+        "password": ""
+    },
+    "tmdb": {
+        "apikey": ""
+    }
+}

--- a/media_cache.py
+++ b/media_cache.py
@@ -286,21 +286,41 @@ class MediaCache:
             async with self.cache_lock:
                 async with aiofiles.open(self.cache_file_path, "r", encoding="utf-8") as f:
                     contents = await f.read()
-                    data = json.loads(contents)
+                data = json.loads(contents)
 
-                    # Convert the list to a dictionary for faster lookups
-                    self.media_items = {str(item["rating_key"]): item for item in data}
-                    self.last_updated = datetime.now()
+                # Support both the current wrapped format ({"updated_at", "items"})
+                # and the legacy bare-list format. Restoring the real timestamp is
+                # what lets cache freshness (update_interval) survive a restart.
+                if isinstance(data, dict):
+                    items = data.get("items", [])
+                    self.last_updated = self._parse_timestamp(data.get("updated_at"))
+                else:
+                    items = data
+                    # Legacy file with no embedded timestamp: fall back to its mtime.
+                    self.last_updated = datetime.fromtimestamp(self.cache_file_path.stat().st_mtime)
 
-                logger.info(
-                    f"Media cache loaded from {self.cache_file_path} with {len(self.media_items)} items"
-                )
+                # Convert the list to a dictionary for faster lookups
+                self.media_items = {str(item["rating_key"]): item for item in items}
+
+            logger.info(
+                f"Media cache loaded from {self.cache_file_path} with {len(self.media_items)} items"
+            )
         except json.JSONDecodeError as e:
             logger.error(f"JSON decode error loading cache: {e}")
             self.media_items = {}
         except Exception as e:
             logger.error(f"Failed to load media cache from disk: {e}")
             self.media_items = {}
+
+    @staticmethod
+    def _parse_timestamp(value) -> Optional[datetime]:
+        """Parse an ISO-8601 timestamp string, or return None if absent/invalid."""
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(value)
+        except (ValueError, TypeError):
+            return None
 
     async def save_cache_to_disk(self) -> None:
         """Snapshot the cache under the lock, then write it to disk.
@@ -333,10 +353,14 @@ class MediaCache:
             # Use a temporary file for safety, then atomically replace.
             temp_file = self.cache_file_path.with_suffix(".tmp")
 
-            # Write in chunks, yielding to the event loop periodically.
+            # Persist the timestamp alongside the items so freshness survives a
+            # restart (otherwise a cache loaded from disk looks brand-new).
+            updated_at = (self.last_updated or datetime.now()).isoformat()
+
+            # Stream items in chunks, yielding to the event loop periodically.
             chunk_size = 100
             async with aiofiles.open(temp_file, "w", encoding="utf-8") as f:
-                await f.write("[\n")
+                await f.write('{"updated_at": ' + json.dumps(updated_at) + ', "items": [\n')
                 for i, item in enumerate(items_list):
                     json_str = json.dumps(item, ensure_ascii=False)
                     if i < len(items_list) - 1:
@@ -344,7 +368,7 @@ class MediaCache:
                     await f.write(json_str + "\n")
                     if i % chunk_size == 0 and i > 0:
                         await asyncio.sleep(0)
-                await f.write("]\n")
+                await f.write("]}\n")
 
             # os.replace is atomic on most platforms.
             if temp_file.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,8 @@ target-version = "py312"
 #   E9  -> syntax / IndentationError / IO errors
 # Broaden this (e.g. add "B", "I", "UP") once the codebase is clean for them.
 select = ["E9", "F"]
+
+[tool.pytest.ini_options]
+# Put the repo root on sys.path so tests can import top-level modules and cogs.
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,114 @@
+"""Unit tests for the pure helper functions.
+
+These cover the deterministic, side-effect-free helpers (response parsing,
+duration/size formatting, argument parsing). Importing the cogs here also acts
+as an import smoke test for the whole dependency set.
+"""
+
+import pytest
+
+from tautulli_wrapper import Tautulli
+from utilities import format_duration
+from cogs.media_commands import (
+    MediaCommands,
+    _format_ms,
+    _truncate,
+    _format_size,
+    _format_bytes_speed,
+)
+
+
+class TestCheckResponse:
+    def test_success(self):
+        assert Tautulli.check_response({"response": {"result": "success"}}) is True
+
+    def test_error_result(self):
+        assert Tautulli.check_response({"response": {"result": "error"}}) is False
+
+    def test_none(self):
+        assert Tautulli.check_response(None) is False
+
+    def test_empty_dict(self):
+        assert Tautulli.check_response({}) is False
+
+
+class TestGetResponseData:
+    def test_extracts_data(self):
+        assert Tautulli.get_response_data({"response": {"data": [1, 2]}}) == [1, 2]
+
+    def test_default_on_none_response(self):
+        assert Tautulli.get_response_data(None, []) == []
+
+    def test_default_when_key_missing(self):
+        assert Tautulli.get_response_data({"response": {}}, {}) == {}
+
+    def test_explicit_null_data_returns_none(self):
+        # 'data' is present but null -> returns None, NOT the default. This is the
+        # exact edge the call sites guard against with `(... or {}).get("data", [])`.
+        assert Tautulli.get_response_data({"response": {"data": None}}, {}) is None
+
+
+class TestFormatDuration:
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (0, "0m"),
+            (59, "0m"),
+            (60, "1m"),
+            (3600, "1h"),
+            (3660, "1h 1m"),
+            (86400, "1d"),
+            (90000, "1d 1h"),
+            (93780, "1d 2h 3m"),
+        ],
+    )
+    def test_format(self, seconds, expected):
+        assert format_duration(seconds) == expected
+
+
+class TestParseRandomArgs:
+    def test_empty(self):
+        assert MediaCommands._parse_random_args(()) == (None, None)
+
+    def test_type_only(self):
+        assert MediaCommands._parse_random_args(("movie",)) == ("movie", None)
+
+    def test_type_and_genre(self):
+        assert MediaCommands._parse_random_args(("tv", "comedy")) == ("tv", "comedy")
+
+    def test_genre_only(self):
+        assert MediaCommands._parse_random_args(("horror",)) == (None, "horror")
+
+    def test_multiword_genre(self):
+        assert MediaCommands._parse_random_args(("science", "fiction")) == (None, "science fiction")
+
+    def test_case_insensitive_type(self):
+        assert MediaCommands._parse_random_args(("Movie",)) == ("movie", None)
+
+
+class TestFormatMs:
+    def test_under_an_hour(self):
+        assert _format_ms(754000) == "12:34"
+
+    def test_over_an_hour(self):
+        assert _format_ms(5025000) == "1:23:45"
+
+
+class TestMiscFormatters:
+    def test_truncate_short(self):
+        assert _truncate("hi", 10) == "hi"
+
+    def test_truncate_long(self):
+        assert _truncate("hello world", 5) == "hell…"
+
+    def test_format_size_gb(self):
+        assert _format_size(2_500_000_000) == "2.50 GB"
+
+    def test_format_size_mb(self):
+        assert _format_size(5_000_000) == "5.0 MB"
+
+    def test_bytes_speed_mb(self):
+        assert _format_bytes_speed(2_000_000) == "2.0 MB/s"
+
+    def test_bytes_speed_kb(self):
+        assert _format_bytes_speed(500_000) == "500 KB/s"

--- a/utilities.py
+++ b/utilities.py
@@ -62,27 +62,25 @@ class UserMappings:
         return next((m for m in mappings if m.get("plex_username") == plex_username), None)
 
 
-def days_hours_minutes(seconds: int) -> str:
-    """Converts seconds to days, hours, minutes."""
-    if not isinstance(seconds, int):
-        raise TypeError("Seconds must be an integer.")
+def format_duration(seconds: int) -> str:
+    """Format a number of seconds into a compact duration like '2d 5h 30m'.
 
-    if seconds < 0:
-        raise ValueError("Seconds must be non-negative.")
-
-    days, seconds = divmod(seconds, 86400)
-    hours, seconds = divmod(seconds, 3600)
-    minutes, _ = divmod(seconds, 60)
+    Days/hours are omitted when zero; minutes are always shown when nothing else
+    is (so a sub-minute value renders as '0m'). This is the canonical duration
+    formatter used across the bot.
+    """
+    days, remainder = divmod(int(seconds), 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes = remainder // 60
 
     parts = []
-    if days > 0:
-        parts.append(f"{days} {'day' if days == 1 else 'days'}")
-    if hours > 0:
-        parts.append(f"{hours} {'hour' if hours == 1 else 'hours'}")
-    if minutes > 0:
-        parts.append(f"{minutes} {'minute' if minutes == 1 else 'minutes'}")
-
-    return ", ".join(parts) if parts else "0 minutes"
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes or not parts:
+        parts.append(f"{minutes}m")
+    return " ".join(parts)
 
 
 def get_git_revision_short_hash() -> str:


### PR DESCRIPTION
Follow-up improvements after the audit PR (#46), implementing the agreed items.

## Persist media-cache timestamp across restarts
The cache file is now wrapped as `{"updated_at", "items"}` so freshness survives a restart — previously `last_updated` was reset to *now* on every load, so a stale on-disk cache looked fresh for another full `update_interval`. Legacy bare-list cache files are still read (falling back to the file mtime).

## Consolidate duration formatters
Collapsed three near-duplicate helpers — `plex_stats._format_watch_duration`, `media_commands._format_seconds`, and the unused `utilities.days_hours_minutes` — into a single canonical `utilities.format_duration()`. (Minor improvement: "Total Watch Time" now shows days for >24h, consistent with the rest of the bot.)

## Config template
Added a committed `config.example.json` (with a `.gitignore` negation so it survives the broad `*.json` ignore) so new users can `cp config.example.json config.json` and fill in values instead of hand-copying from the README.

## Tests + CI
Added `pytest` unit tests for the pure helpers (`check_response`/`get_response_data`, `format_duration`, `_parse_random_args`, and the size/speed/clock formatters) and a CI `test` job that installs the pinned requirements and runs them — which also verifies the dependency set resolves on the supported Python. **30 tests pass** locally on 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)