### PR TITLE
Convert status_task to nextcord ext.tasks.loop

### DIFF
--- a/cogs/server_commands.py
+++ b/cogs/server_commands.py
@@ -5,7 +5,7 @@ import logging
 
 import aiohttp
 import nextcord
-from nextcord.ext import commands
+from nextcord.ext import commands, tasks
 
 from config import config
 from utilities import (
@@ -25,14 +25,8 @@ class ServerCommands(commands.Cog):
         self.tautulli: Tautulli = bot.shared_resources.get("tautulli")
         self.plex_embed_color = config.get("ui", "plex_embed_color", 0xE5A00D)
         self.plex_image = config.get("ui", "plex_image")
-        self._status_task = None
-        self.bot.loop.create_task(self.initialize())
-
-    async def initialize(self):
-        await self.bot.wait_until_ready()
-        self.tautulli.initialize()
-        await self._log_startup_info()
-        self._status_task = self.bot.loop.create_task(self.status_task())
+        self._display_streams = True  # presence alternates between stream stats and a help hint
+        self.status_task.start()  # type: ignore[attr-defined]
 
     async def _log_startup_info(self):
         """Log Tautulli connectivity and the bot's git version, once, at startup."""
@@ -67,38 +61,40 @@ class ServerCommands(commands.Cog):
     def cog_unload(self):
         # Stop the background presence loop. The shared Tautulli client is owned by
         # the bot (PlexBot.close()) and must not be closed here.
-        if self._status_task is not None:
-            self._status_task.cancel()
+        self.status_task.cancel()  # type: ignore[attr-defined]
 
+    @tasks.loop(seconds=15)
     async def status_task(self):
-        """Background task to update the bot's presence."""
-        display_streams = True  # Toggles between showing streams and help command
-        while not self.bot.is_closed():
-            try:
-                response = await self.tautulli.get_activity()
-                if not Tautulli.check_response(response):
-                    logger.error("Failed to retrieve activity from Tautulli.")
-                    await asyncio.sleep(15)
-                    continue
-                data = Tautulli.get_response_data(response, {})
-                stream_count = data.get("stream_count", 0)
-                wan_bandwidth_mbps = round(data.get("wan_bandwidth", 0) / 1000, 1)
+        """Update the bot's presence, alternating between stream stats and a help hint."""
+        try:
+            response = await self.tautulli.get_activity()
+            if not Tautulli.check_response(response):
+                logger.error("Failed to retrieve activity from Tautulli.")
+                return
+            data = Tautulli.get_response_data(response, {})
+            stream_count = data.get("stream_count", 0)
+            wan_bandwidth_mbps = round(data.get("wan_bandwidth", 0) / 1000, 1)
 
-                if display_streams:
-                    activity_text = f"{stream_count} streams at {wan_bandwidth_mbps} mbps"
-                    activity_type = nextcord.ActivityType.playing
-                else:
-                    activity_text = ": plex help"
-                    activity_type = nextcord.ActivityType.listening
+            if self._display_streams:
+                activity_text = f"{stream_count} streams at {wan_bandwidth_mbps} mbps"
+                activity_type = nextcord.ActivityType.playing
+            else:
+                activity_text = ": plex help"
+                activity_type = nextcord.ActivityType.listening
 
-                await self.bot.change_presence(
-                    activity=nextcord.Activity(type=activity_type, name=activity_text)
-                )
-                display_streams = not display_streams  # Toggle the display mode
-            except Exception as e:
-                logger.error(f"Error in status_task(): {e}")
+            await self.bot.change_presence(
+                activity=nextcord.Activity(type=activity_type, name=activity_text)
+            )
+            self._display_streams = not self._display_streams  # Toggle the display mode
+        except Exception as e:
+            logger.error(f"Error in status_task(): {e}")
 
-            await asyncio.sleep(15)  # Control how often to update the status
+    @status_task.before_loop  # type: ignore[attr-defined]
+    async def _before_status_task(self):
+        """Wait for the gateway, initialize Tautulli, and log startup info before the first tick."""
+        await self.bot.wait_until_ready()
+        self.tautulli.initialize()
+        await self._log_startup_info()
 
     @commands.command()
     async def status(self, ctx):

--- a/plexbot.py
+++ b/plexbot.py
@@ -133,11 +133,11 @@ class PlexBot(commands.Bot):
     async def close(self) -> None:
         """Shut down the gateway first, then close shared aiohttp sessions.
 
-        super().close() stops the gateway and lets background loops (e.g.
-        ServerCommands.status_task, gated on is_closed()) observe shutdown, so we
-        don't tear the shared Tautulli/TMDB sessions down while a task is still
-        mid-request — which would otherwise error or silently re-open a new,
-        never-closed session via Tautulli._ensure_session().
+        super().close() unloads the cogs (cancelling background loops like
+        ServerCommands.status_task via cog_unload) and stops the gateway before we
+        close the shared Tautulli/TMDB sessions here, so we don't tear those sessions
+        down while a task is still mid-request — which would otherwise error or
+        silently re-open a new, never-closed session via Tautulli._ensure_session().
         """
         await super().close()
 


### PR DESCRIPTION
Replaces the hand-rolled presence loop (`while not self.bot.is_closed()` started via `bot.loop.create_task(self.initialize())` in `__init__`) with the modern `@tasks.loop(seconds=15)` helper.

- Toggle state moves from a loop-local to `self._display_streams`.
- One-time startup (`wait_until_ready` → Tautulli init → version logging) moves to a `@before_loop` hook.
- `cog_unload` cancels the loop; the per-iteration `try/except` is kept so a Tautulli hiccup logs and the loop keeps ticking.
- On shutdown the loop is cancelled cleanly: `commands.Bot.close()` unloads cogs (firing `cog_unload`) before the gateway and the shared Tautulli session close. Updated the `PlexBot.close()` docstring to describe that.

**Verification:** `ruff` clean, 30/30 tests pass, runtime smoke test (loop start → before_loop init → tick sets presence → toggle flips → `cog_unload` cancels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)